### PR TITLE
Remove Firefox as supported for screen share

### DIFF
--- a/doc_source/chime-web-app.md
+++ b/doc_source/chime-web-app.md
@@ -61,7 +61,7 @@ The Amazon Chime web application uses your default audio device\. If you use Moz
 
 ## Screen sharing options for the Amazon Chime web application<a name="web-app-sharing"></a>
 
-You can share your screen or an application window, if you are using the latest three versions of Mozilla Firefox or Google Chrome\. Screen share is available for Chrome version 72 and Firefox version 66 or later\.
+You can share your screen or an application window if you are using the latest three versions of Google Chrome\. Screen share is available for Chrome version 72 or later\.
 
 **To share your screen or application window**
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I was attempting to use Chime to screen share through Firefox, but it isn't supported. I'm on Firefox version 89 (on Ubuntu 20.04)

When I do try to screen share, I get an error message pop up as part of the chime web app that says the following:

> Screen share is available for the latest version of Chrome and Chromium Edge, and native Chime desktop clients.

I don't believe that screen sharing is available on Firefox so this wording here seems like a mistake. (Maybe it was related to some different feature that _isn't_ screen sharing?)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
